### PR TITLE
fix: 🐛 geth node introspection if node_info method is disabled

### DIFF
--- a/src/abi.ts
+++ b/src/abi.ts
@@ -313,6 +313,14 @@ export class AbiRepository implements ManagedResource {
     }
 
     public decodeLogEvent(logEvent: RawLogResponse, contractFingerprint?: string): DecodedLogEvent | undefined {
+        if (!Array.isArray(logEvent.topics) || logEvent.topics.length === 0) {
+            debug(
+                'No topics in log event tx=%s idx=%s - nothing to decode',
+                logEvent.transactionHash,
+                logEvent.logIndex
+            );
+            return;
+        }
         const sigHash = logEvent.topics[0].slice(2);
         const match = this.signatures.get(sigHash);
         if (match != null) {

--- a/src/eth/client.ts
+++ b/src/eth/client.ts
@@ -115,6 +115,7 @@ export class BatchedEthereumClient extends EthereumClient {
                 callback: (e, result) => {
                     if (e) {
                         reject(e);
+                        return;
                     }
                     try {
                         checkError(result);

--- a/src/eth/jsonrpc.ts
+++ b/src/eth/jsonrpc.ts
@@ -41,8 +41,8 @@ export class JsonRpcError extends Error {
     }
 }
 
-export function checkError(msg: JsonRpcResponse) {
-    if (msg.error) {
+export function checkError(msg?: JsonRpcResponse) {
+    if (msg?.error) {
         throw new JsonRpcError(msg.error.message, msg.error.code, msg.error.data);
     }
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,10 +1,9 @@
 import { hostname } from 'os';
 import { EthloggerConfig } from './config';
-import { KNOWN_NETOWORK_NAMES } from './eth/networks';
 import { NodePlatformAdapter } from './platforms';
 import { createModuleDebug } from './utils/debug';
 import { removeEmtpyValues } from './utils/obj';
-import { subsituteVariablesInValues, subsituteVariables } from './utils/vars';
+import { subsituteVariables, subsituteVariablesInValues } from './utils/vars';
 
 const { debug } = createModuleDebug('meta');
 
@@ -63,7 +62,7 @@ export function substituteVariablesInHecConfig(
         ENODE: platformAdapter.enode ?? undefined,
         PLATFORM: platformAdapter.name,
         NETWORK_ID: networkId != null ? String(networkId) : undefined,
-        NETWORK: config.eth.network ?? (networkId != null ? KNOWN_NETOWORK_NAMES[networkId] : undefined),
+        NETWORK: platformAdapter.networkName ?? undefined,
         PID: String(pid),
         VERSION: ethloggerVersion,
         NODE_VERSION: nodeVersion,

--- a/src/platforms/geth.ts
+++ b/src/platforms/geth.ts
@@ -1,13 +1,14 @@
 import { NodePlatformAdapter } from '.';
 import { EthereumClient } from '../eth/client';
+import { KNOWN_NETOWORK_NAMES } from '../eth/networks';
 import { clientVersion, gethMemStats, gethMetrics, gethNodeInfo, gethPeers, gethTxpool } from '../eth/requests';
 import { GethMemStats, GethMetrics, GethNodeInfoResponse, GethPeer } from '../eth/responses';
 import { formatPendingTransaction } from '../format';
 import { NodeInfo, PendingTransactionMessage } from '../msgs';
 import { OutputMessage } from '../output';
 import { createModuleDebug } from '../utils/debug';
+import { durationStringToMs, parseAbbreviatedNumber } from '../utils/parse';
 import { captureDefaultMetrics, fetchDefaultNodeInfo } from './generic';
-import { parseAbbreviatedNumber, durationStringToMs } from '../utils/parse';
 
 const { debug, error } = createModuleDebug('platforms:geth');
 
@@ -184,6 +185,10 @@ export class GethAdapter implements NodePlatformAdapter {
 
     public get protocolVersion(): number | null {
         return this.nodeInfo?.protocolVersion ?? null;
+    }
+
+    public get networkName(): string | null {
+        return this.network ?? (this.networkId != null ? KNOWN_NETOWORK_NAMES[this.networkId] : null) ?? null;
     }
 
     public async captureNodeStats(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]> {

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -9,6 +9,7 @@ export interface NodePlatformAdapter {
     readonly enode: string | null;
     readonly networkId: number | null;
     readonly protocolVersion: number | null;
+    readonly networkName: string | null;
     initialize?(ethClient: EthereumClient): Promise<void>;
     captureNodeStats(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]>;
     captureNodeInfo(ethClient: EthereumClient): Promise<NodeInfo>;

--- a/src/platforms/parity.ts
+++ b/src/platforms/parity.ts
@@ -5,6 +5,7 @@ import { createModuleDebug } from '../utils/debug';
 import { NodeInfo } from '../msgs';
 import { fetchDefaultNodeInfo, captureDefaultMetrics } from './generic';
 import { ParityMode, ParityNodeKind } from '../eth/responses';
+import { KNOWN_NETOWORK_NAMES } from '../eth/networks';
 
 const { debug } = createModuleDebug('platforms:parity');
 
@@ -65,6 +66,10 @@ export class ParityAdapter implements NodePlatformAdapter {
 
     public get protocolVersion(): number | null {
         return this.nodeInfo?.protocolVersion ?? null;
+    }
+
+    public get networkName(): string | null {
+        return this.network ?? (this.networkId != null ? KNOWN_NETOWORK_NAMES[this.networkId] : null) ?? null;
     }
 
     public async captureNodeStats(eth: EthereumClient, captureTime: number) {


### PR DESCRIPTION
Fixed error when talking to Geth nodes with admin_nodeInfo method
disabled by falling back to the generic node platform adapter. Also
improved logging of enode field value in node info messages.