### PR TITLE
fix: 🐛 avoid collecting pending transactions if not supported

### DIFF
--- a/src/nodestats.ts
+++ b/src/nodestats.ts
@@ -178,6 +178,7 @@ export class NodeStatsCollector implements ManagedResource {
                 ethClient.transport.source,
                 platformAdapter.name
             );
+            return;
         }
 
         await this.periodicallyCollect(


### PR DESCRIPTION
If pending transactions endpoints are not supported by the ethereum
node, avoid starting periodic collection (since it would fail).