### PR TITLE
Extended peer information with dedicated config

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -543,6 +543,34 @@
             },
             "type": "object"
         },
+        "PeerInfoConfigSchema": {
+            "description": "Periodic collection of detailed peer information.\nNote that this is only possible with certain types of ethereum nodes (geth atm)",
+            "properties": {
+                "collectInterval": {
+                    "description": "Interval in which to collect peer information",
+                    "type": ["string", "number"]
+                },
+                "enabled": {
+                    "description": "Enable or disable collection of peer informataion",
+                    "type": "boolean"
+                },
+                "retryWaitTime": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ExponentalBackoffConfig"
+                        },
+                        {
+                            "$ref": "#/definitions/LinearBackoffConfig"
+                        },
+                        {
+                            "type": ["string", "number"]
+                        }
+                    ],
+                    "description": "Wait time before retrying to collect peer information after failure"
+                }
+            },
+            "type": "object"
+        },
         "PendingTxConfigSchema": {
             "description": "Periodic collection of pending transactions",
             "properties": {
@@ -660,6 +688,10 @@
                 }
             ],
             "description": "In the output configuration you can specify where ethlogger will send generated\nmetrics and events to. By default it will send all information to Splunk HEC,\nbut you can instead send it to console output or a file."
+        },
+        "peerInfo": {
+            "$ref": "#/definitions/PeerInfoConfigSchema",
+            "description": "Settings for collecting peer informataion from the node"
         },
         "pendingTx": {
             "$ref": "#/definitions/PendingTxConfigSchema",

--- a/defaults.ethlogger.yaml
+++ b/defaults.ethlogger.yaml
@@ -97,5 +97,9 @@ pendingTx:
     enabled: false
     collectInterval: 10s
     retryWaitTime: 10s
+peerInfo:
+    enabled: false
+    collectInterval: 10s
+    retryWaitTime: 10s
 internalMetrics:
     collectInterval: 1s

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,6 +44,9 @@ OPTIONS
   --[no-]collect-node-metrics
       Enables collection of node metrics
 
+  --[no-]collect-peer-info
+      Enables collection of detailed peer information
+
   --[no-]collect-pending-transactions
       Enables collection of pending transactions
 
@@ -128,6 +131,7 @@ OPTIONS
 | `COLLECT_NODE_METRICS`            | `boolean` | Enables collection of node metrics                                                                                                                                                       |
 | `COLLECT_NODE_INFO`               | `boolean` | Enables collection of node info events                                                                                                                                                   |
 | `COLLECT_PENDING_TX`              | `boolean` | Enables collection of pending transactions                                                                                                                                               |
+| `COLLECT_PEER_INFO`               | `boolean` | Enables collection of detailed peer information                                                                                                                                          |
 | `COLLECT_INTERNAL_METRICS`        | `boolean` | Enables collection of ethlogger-internal metrics                                                                                                                                         |
 | `SPLUNK_HEC_URL`                  | `string`  | URL to connect to Splunk HTTP Event Collector. You can either specify just the base URL (without path) and the default path will automatically appended or a full URL                    |
 | `SPLUNK_HEC_TOKEN`                | `string`  | Token to authenticate against Splunk HTTP Event Collector                                                                                                                                |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,7 @@ Root configuration schema for ethlogger
 | `nodeMetrics`     | [`NodeMetrics`](#NodeMetrics)                                                                                                      | Settings for the node metrics collector                                                                                                                                                                                |
 | `nodeInfo`        | [`NodeInfo`](#NodeInfo)                                                                                                            | Settings for the node info collector                                                                                                                                                                                   |
 | `pendingTx`       | [`PendingTx`](#PendingTx)                                                                                                          | Settings for collecting pending transactions from node                                                                                                                                                                 |
+| `peerInfo`        | [`PeerInfo`](#PeerInfo)                                                                                                            | Settings for collecting peer informataion from the node                                                                                                                                                                |
 | `internalMetrics` | [`InternalMetrics`](#InternalMetrics)                                                                                              | Settings for internal metrics collection                                                                                                                                                                               |
 
 ### Ethereum
@@ -269,6 +270,16 @@ Periodic collection of pending transactions
 | `enabled`         | `boolean`               | Enable or disable collection of pending transactions                    |
 | `collectInterval` | [`Duration`](#Duration) | Interval in which to collect pending transactions                       |
 | `retryWaitTime`   | [`WaitTime`](#WaitTime) | Wait time before retrying to collect pending transactions after failure |
+
+### PeerInfo
+
+Periodic collection of detailed peer information. Note that this is only possible with certain types of ethereum nodes (geth atm)
+
+| Name              | Type                    | Description                                                         |
+| ----------------- | ----------------------- | ------------------------------------------------------------------- |
+| `enabled`         | `boolean`               | Enable or disable collection of peer informataion                   |
+| `collectInterval` | [`Duration`](#Duration) | Interval in which to collect peer information                       |
+| `retryWaitTime`   | [`WaitTime`](#WaitTime) | Wait time before retrying to collect peer information after failure |
 
 ### InternalMetrics
 

--- a/examples/quorum/docker-compose.yaml
+++ b/examples/quorum/docker-compose.yaml
@@ -344,6 +344,8 @@ services:
             - SPLUNK_INTERNAL_INDEX=metrics
             - SPLUNK_HEC_REJECT_INVALID_CERTS=false
             - ABI_DIR=/abi
+            - COLLECT_PENDING_TX=true
+            - COLLECT_PEER_INFO=true
             - DEBUG=ethlogger:abi:*
         volumes:
             - ./abi:/abi
@@ -370,6 +372,8 @@ services:
             - SPLUNK_HEC_REJECT_INVALID_CERTS=false
             - COLLECT_BLOCKS=false
             - ABI_DIR=/abi
+            - COLLECT_PENDING_TX=true
+            - COLLECT_PEER_INFO=true
             - DEBUG=ethlogger:abi:*
         volumes:
             - ./abi:/abi

--- a/src/cliflags.ts
+++ b/src/cliflags.ts
@@ -53,6 +53,11 @@ export const CLI_FLAGS = {
         env: 'COLLECT_PENDING_TX',
         description: 'Enables collection of pending transactions',
     }),
+    'collect-peer-info': flags.boolean({
+        allowNo: true,
+        env: 'COLLECT_PEER_INFO',
+        description: 'Enables collection of detailed peer information',
+    }),
     'collect-internal-metrics': flags.boolean({
         allowNo: true,
         env: 'COLLECT_INTERNAL_METRICS',

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,8 @@ export interface EthloggerConfigSchema {
     nodeInfo: NodeInfoConfigSchema;
     /** Settings for collecting pending transactions from node */
     pendingTx: PendingTxConfigSchema;
+    /** Settings for collecting peer informataion from the node */
+    peerInfo: PeerInfoConfigSchema;
     /** Settings for internal metrics collection */
     internalMetrics: InternalMetricsConfigSchema;
 }
@@ -60,6 +62,7 @@ export interface EthloggerConfig {
     nodeMetrics: NodeMetricsConfig;
     nodeInfo: NodeInfoConfig;
     pendingTx: PendingTxConfig;
+    peerInfo: PeerInfoConfig;
     internalMetrics: InternalMetricsConfig;
 }
 
@@ -235,6 +238,24 @@ export interface PendingTxConfigSchema {
 }
 
 export interface PendingTxConfig extends Omit<PendingTxConfigSchema, 'retryWaitTime'> {
+    collectInterval: Duration;
+    retryWaitTime: WaitTime;
+}
+
+/**
+ * Periodic collection of detailed peer information.
+ * Note that this is only possible with certain types of ethereum nodes (geth atm)
+ */
+export interface PeerInfoConfigSchema {
+    /** Enable or disable collection of peer informataion */
+    enabled: boolean;
+    /** Interval in which to collect peer information */
+    collectInterval: DurationConfig;
+    /** Wait time before retrying to collect peer information after failure */
+    retryWaitTime: WaitTimeConfig;
+}
+
+export interface PeerInfoConfig extends Omit<PeerInfoConfigSchema, 'retryWaitTime'> {
     collectInterval: Duration;
     retryWaitTime: WaitTime;
 }
@@ -812,6 +833,15 @@ export async function loadEthloggerConfig(flags: CliFlags, dryRun: boolean = fal
                 false,
             collectInterval: parseDuration(defaults.pendingTx?.collectInterval) ?? 30000,
             retryWaitTime: waitTimeFromConfig(defaults.pendingTx?.retryWaitTime) ?? 30000,
+        },
+        peerInfo: {
+            enabled:
+                flags['collect-peer-info'] ??
+                parseBooleanEnvVar(CLI_FLAGS['collect-peer-info'].env) ??
+                defaults.peerInfo?.enabled ??
+                false,
+            collectInterval: parseDuration(defaults.peerInfo?.collectInterval) ?? 10000,
+            retryWaitTime: waitTimeFromConfig(defaults.peerInfo?.retryWaitTime) ?? 10000,
         },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
 import { Command } from '@oclif/command';
 import debugModule from 'debug';
 import { inspect } from 'util';
+import { ContractInfo } from './abi/contract';
 import { AbiRepository } from './abi/repo';
 import { BlockWatcher } from './blockwatcher';
 import { Checkpoint } from './checkpoint';
 import { CLI_FLAGS } from './cliflags';
-import { ConfigError, loadEthloggerConfig, EthloggerConfig } from './config';
-import { ContractInfo } from './abi/contract';
+import { ConfigError, EthloggerConfig, loadEthloggerConfig } from './config';
 import { BatchedEthereumClient, EthereumClient } from './eth/client';
 import { HttpTransport } from './eth/http';
+import { checkHealthState, HealthStateMonitor } from './health';
 import { HecClient } from './hec';
 import { introspectTargetNodePlatform } from './introspect';
 import { substituteVariablesInHecConfig } from './meta';
@@ -20,7 +21,6 @@ import LRUCache from './utils/lru';
 import { ManagedResource, shutdownAll } from './utils/resource';
 import { waitForSignal } from './utils/signal';
 import { InternalStatsCollector } from './utils/stats';
-import { checkHealthState, HealthStateMonitor } from './health';
 
 const { debug, error, info } = createModuleDebug('cli');
 
@@ -154,6 +154,7 @@ class Ethlogger extends Command {
             nodeMetrics: config.nodeMetrics,
             nodeInfo: config.nodeInfo,
             pendingTx: config.pendingTx,
+            peerInfo: config.peerInfo,
         });
         addResource(nodeStatsCollector);
         internalStatsCollector.addSource(nodeStatsCollector, 'nodeStatsCollector');

--- a/src/platforms/generic.ts
+++ b/src/platforms/generic.ts
@@ -224,7 +224,13 @@ export class GenericNodeAdapter implements NodePlatformAdapter {
         return fetchPendingTransactions(ethClient, captureTime);
     }
 
-    public async supportsPendingTransactions(): Promise<boolean> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public async supportsPendingTransactions(_: EthereumClient): Promise<boolean> {
         return this.supports?.pendingTransactions ?? false;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    public async supportsPeerInfo(_: EthereumClient): Promise<boolean> {
+        return false;
     }
 }

--- a/src/platforms/geth.ts
+++ b/src/platforms/geth.ts
@@ -6,7 +6,7 @@ import { NodeInfo, PendingTransactionMessage, NodeMetricsMessage } from '../msgs
 import { OutputMessage } from '../output';
 import { createModuleDebug } from '../utils/debug';
 import { durationStringToMs, parseAbbreviatedNumber } from '../utils/parse';
-import { captureDefaultMetrics, GenericNodeAdapter } from './generic';
+import { captureDefaultMetrics, GenericNodeAdapter, checkRpcMethodSupport } from './generic';
 
 const { debug, error } = createModuleDebug('platforms:geth');
 
@@ -162,12 +162,23 @@ export class GethAdapter extends GenericNodeAdapter {
         const [defaultMetrics, gethMetrics] = await Promise.all([
             captureDefaultMetrics(ethClient, captureTime),
             captureGethMetrics(ethClient, captureTime),
-            capturePeers(ethClient, captureTime),
         ]);
         return [defaultMetrics, gethMetrics];
     }
 
+    public async supportsPendingTransactions(ethClient: EthereumClient): Promise<boolean> {
+        return await checkRpcMethodSupport(ethClient, gethTxpool());
+    }
+
     public async capturePendingTransactions(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]> {
         return await captureTxpoolData(ethClient, captureTime);
+    }
+
+    public async supportsPeerInfo(ethClient: EthereumClient) {
+        return await checkRpcMethodSupport(ethClient, gethPeers());
+    }
+
+    public async capturePeerInfo?(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]> {
+        return await capturePeers(ethClient, captureTime);
     }
 }

--- a/src/platforms/index.ts
+++ b/src/platforms/index.ts
@@ -20,4 +20,6 @@ export interface NodePlatformAdapter {
     captureNodeInfo(ethClient: EthereumClient): Promise<NodeInfo>;
     capturePendingTransactions(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]>;
     supportsPendingTransactions(ethClient: EthereumClient): Promise<boolean>;
+    capturePeerInfo?(ethClient: EthereumClient, captureTime: number): Promise<OutputMessage[]>;
+    supportsPeerInfo(ethClient: EthereumClient): Promise<boolean>;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -119,6 +119,11 @@ test('defaults', async () => {
                     },
                     "type": "hec",
                   },
+                  "peerInfo": Object {
+                    "collectInterval": 10000,
+                    "enabled": false,
+                    "retryWaitTime": 10000,
+                  },
                   "pendingTx": Object {
                     "collectInterval": 10000,
                     "enabled": false,


### PR DESCRIPTION
Moved extended peer info collection (only available for geth atm) to
have its own configuration and schedule, to be consistent with how
pending transaction collection is configured.