### PR TITLE
docs: ✏️ Update Besu example to 1.4.4 with native Splunk logging

### DIFF
--- a/examples/besu/README.md
+++ b/examples/besu/README.md
@@ -16,8 +16,11 @@ $ docker-compose up -d
 2. Wait for all containers to start.
    You can rely on the output of `docker ps` to see the state of services.
 
-3. Then go to [http://localhost:18000](http://localhost:18000) to explore the data produced by ethlogger.
-   Login using user `admin` and password `changeme`
+3. Go to [http://localhost:18000](http://localhost:18000) and login using user `admin` and password `changeme`.
+
+4. [Open the Ethereum Basis application](http://localhost:18000/en-US/app/ethereum-basics/introduction) to explore block data.
+
+5. You can search for logs [with the search `index="logs"`](http://localhost:18000/en-US/app/search/search?q=search%20index%3D%22logs%22).
 
 ## Note
 

--- a/examples/besu/docker-compose.yaml
+++ b/examples/besu/docker-compose.yaml
@@ -11,7 +11,6 @@ services:
             - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
         ports:
             - 18000:8000
-            - 18088:8088
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:8000']
             interval: 5s
@@ -47,7 +46,7 @@ services:
         depends_on:
             - splunk
     besu:
-        image: hyperledger/besu:1.4.2
+        image: hyperledger/besu:1.4.4
         container_name: besu
         environment:
             - BESU_RPC_HTTP_ENABLED=true
@@ -61,14 +60,9 @@ services:
             - BESU_RPC_HTTP_API=admin,eth,debug,miner,net,txpool,priv,trace,web3
             - BESU_RPC_HTTP_CORS_ORIGIN="all"
             - BESU_LOGGING=trace
-        logging:
-            driver: splunk
-            options:
-                splunk-token: 11111111-1111-1111-1111-1111111111113
-                splunk-url: https://localhost:18088
-                splunk-index: logs
-                splunk-sourcetype: besulogs
-                splunk-insecureskipverify: 'true'
-                splunk-verify-connection: 'false'
-                splunk-format: 'raw'
-                tag: '{{.Name}}-{{.ID}}'
+            # Splunk logging configuration
+            - LOGGER=Splunk
+            - SPLUNK_URL=https://splunk:8088
+            - SPLUNK_INDEX=logs
+            - SPLUNK_TOKEN=11111111-1111-1111-1111-1111111111113
+            - SPLUNK_SKIPTLSVERIFY=true


### PR DESCRIPTION
Update the Besu example to use the newly released 1.4.4. Add more
detailed instructions for users to explore block data and logs. Use the
native Splunk logging capability instead of docker logging.