### PR TITLE
docs: ✏️  fix docker logging driver in examples

### DIFF
--- a/examples/besu/README.md
+++ b/examples/besu/README.md
@@ -26,6 +26,7 @@ $ docker-compose up -d
 
 > This example is not meant to be used in a production setup.
 > Splunk and ethlogger persist data using local volumes. If you would like to start clean run the following.
+> Using the logging driver to log to a container in the same docker-compose stack shouldn't be used in production.
 
 ```sh-session
 $ docker-compose down

--- a/examples/besu/docker-compose.yaml
+++ b/examples/besu/docker-compose.yaml
@@ -1,5 +1,17 @@
 version: '3.6'
 
+x-logging: &default-logging
+    driver: splunk
+    options:
+        splunk-token: 11111111-1111-1111-1111-1111111111113
+        splunk-url: https://localhost:8088
+        splunk-index: logs
+        splunk-sourcetype: docker
+        splunk-insecureskipverify: 'true'
+        splunk-verify-connection: 'false'
+        splunk-format: 'raw'
+        tag: '{{.Name}}-{{.ID}}'
+
 services:
     splunk:
         image: splunk/splunk:latest
@@ -11,6 +23,7 @@ services:
             - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
         ports:
             - 8000:8000
+            - 8088:8088
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:8000']
             interval: 5s
@@ -20,6 +33,7 @@ services:
             - ./splunk.yml:/tmp/defaults/default.yml
             - /opt/splunk/var
             - /opt/splunk/etc
+
     ethlogger:
         image: splunkdlt/ethlogger:latest
         container_name: ethlogger
@@ -42,7 +56,9 @@ services:
             - ./:/app
         depends_on:
             - splunk
-        restart: always
+        restart: unless-stopped
+        logging: *default-logging
+
     besu:
         image: hyperledger/besu:1.4.4
         container_name: besu
@@ -64,3 +80,4 @@ services:
             - SPLUNK_INDEX=logs
             - SPLUNK_TOKEN=11111111-1111-1111-1111-1111111111113
             - SPLUNK_SKIPTLSVERIFY=true
+        logging: *default-logging

--- a/examples/geth-multiple-nodes/README.md
+++ b/examples/geth-multiple-nodes/README.md
@@ -26,6 +26,7 @@ $ docker-compose up -d
 
 > This example is not meant to be used in a production setup.
 > Splunk and ethlogger persist data using local volumes. If you would like to start clean run the following.
+> Using the logging driver to log to a container in the same docker-compose stack shouldn't be used in production.
 
 ```sh-session
 $ docker-compose down

--- a/examples/geth-multiple-nodes/docker-compose.yaml
+++ b/examples/geth-multiple-nodes/docker-compose.yaml
@@ -40,7 +40,7 @@ x-logging: &default-logging
     driver: splunk
     options:
         splunk-token: 11111111-1111-1111-1111-1111111111113
-        splunk-url: https://172.25.0.100:8088
+        splunk-url: https://localhost:8088
         splunk-index: logs
         splunk-sourcetype: docker
         splunk-insecureskipverify: 'true'
@@ -59,6 +59,7 @@ services:
             - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
         ports:
             - 8000:8000
+            - 8088:8088
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:8000']
             interval: 5s

--- a/examples/geth-single-node/README.md
+++ b/examples/geth-single-node/README.md
@@ -26,6 +26,7 @@ $ docker-compose up -d
 
 > This example is not meant to be used in a production setup.
 > Splunk and ethlogger persist data using local volumes. If you would like to start clean run the following.
+> Using the logging driver to log to a container in the same docker-compose stack shouldn't be used in production.
 
 ```sh-session
 $ docker-compose down

--- a/examples/geth-single-node/docker-compose.yaml
+++ b/examples/geth-single-node/docker-compose.yaml
@@ -4,7 +4,7 @@ x-logging: &default-logging
     driver: splunk
     options:
         splunk-token: 11111111-1111-1111-1111-1111111111113
-        splunk-url: https://172.25.0.100:8088
+        splunk-url: https://localhost:8088
         splunk-index: logs
         splunk-sourcetype: docker
         splunk-insecureskipverify: 'true'
@@ -23,6 +23,7 @@ services:
             - SPLUNK_APPS_URL=https://github.com/splunk/ethereum-basics/releases/download/latest/ethereum-basics.tgz
         ports:
             - 8000:8000
+            - 8088:8088
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:8000']
             interval: 5s


### PR DESCRIPTION
This fixes the docker logging driver in the Geth examples and adds the docker logging driver for Besu.