### PR TITLE
Fix for geth node metrics errors in ethlogger output

### DIFF
--- a/src/platforms/generic.ts
+++ b/src/platforms/generic.ts
@@ -24,7 +24,7 @@ import { prefixKeys } from '../utils/obj';
 
 const { debug, warn, error } = createModuleDebug('platforms:generic');
 
-export async function checkRpcMethodSupport(eth: EthereumClient, req: EthRequest<[], any>): Promise<boolean> {
+export async function checkRpcMethodSupport(eth: EthereumClient, req: EthRequest<any, any>): Promise<boolean> {
     try {
         debug('Checking if RPC method %s is supported by ethereum node', req.method);
         await eth.request(req, { immediate: true });


### PR DESCRIPTION
Added new check whether geth supports the debug_metrics RPC method,
since support has been dropped in newer versions (as of 1.9). This fixes
the issue where ethlogger output is spammed with error messages of the
node metrics request failing.

✅ Closes: #49