### PR TITLE
docs: ✏️  update quorum-wizard install command

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/examples/quorum/README.md
+++ b/examples/quorum/README.md
@@ -5,7 +5,7 @@ This example uses [`quorum-wizard`]() to generate a docker-compose configuration
 ## Run
 
 ```sh-session
-npm install -g quorum-wizard@beta
+npm install -g quorum-wizard@next
 quorum-wizard
 ```
 


### PR DESCRIPTION
Quorum-wizard release was cut including splunk under the `next` tag instead of `beta`. Will update again when it makes it into the `latest`/default tag.