### PR TITLE
Broken References in Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,6 @@
 # Documentation
 
 -   [CLI reference](./cli.md)
--   [Data collection](./datacollection.md)
 -   [ABI decoding](./abi.md)
 -   [Configuration reference](./configuration.md)
 -   [Developer setup](./developing.md)

--- a/docs/abi.md
+++ b/docs/abi.md
@@ -101,7 +101,7 @@ For cases where we can find a match with beweteen a deployed contract and a supp
 If anonymous ABI encoding is enabled (which it is by default), then this reduced amount of informataion is emitted. In addition to the ABIs supplied by the user, ethlogger ships with a standard set of function and event signatures that are compliled from from external sources:
 
 -   https://github.com/MrLuit/evm
--   https://4byte.directory
+-   https://www.4byte.directory
 
 Compiled lists can be found here:
 


### PR DESCRIPTION
Change 1 : `docs/README.md`
Hide missing page from documentation.

Change 2: `docs/abi.md`
Broken external link to 4byte.directory. Possibly because their servers are not looking for requests without "www".