### PR TITLE
test: 💍 fix retry test bounds

### DIFF
--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -15,7 +15,7 @@ describe('retry', () => {
 
         await expect(p).rejects.toMatchInlineSnapshot(`[Error: nope]`);
         expect(tried).toBe(5);
-        expect(Date.now() - startTime).toBeGreaterThanOrEqual(5);
+        expect(Date.now() - startTime).toBeGreaterThanOrEqual(4);
         expect(Date.now() - startTime).toBeLessThan(100);
     });
 
@@ -36,7 +36,7 @@ describe('retry', () => {
 
         await expect(p).resolves.toMatchInlineSnapshot(`"RESULT"`);
         expect(tried).toBe(5);
-        expect(Date.now() - startTime).toBeGreaterThanOrEqual(5);
+        expect(Date.now() - startTime).toBeGreaterThanOrEqual(4);
         expect(Date.now() - startTime).toBeLessThan(100);
     });
 


### PR DESCRIPTION
Some retry tests are expecting total time delta to be equal to ```(number_of_tries) * (time_between_tries)``` instead of ```(number_of_tries - 1) * (time_between_tries)```